### PR TITLE
Fix Python syntax errors and undefined names in examples

### DIFF
--- a/examples/Python/demo4.py
+++ b/examples/Python/demo4.py
@@ -18,7 +18,7 @@ interrupted = False
 
 
 def audioRecorderCallback(fname):
-    print "converting audio to text"
+    print("converting audio to text")
     r = sr.Recognizer()
     with sr.AudioFile(fname) as source:
         audio = r.record(source)  # read the entire audio file
@@ -29,9 +29,9 @@ def audioRecorderCallback(fname):
         # instead of `r.recognize_google(audio)`
         print(r.recognize_google(audio))
     except sr.UnknownValueError:
-        print "Google Speech Recognition could not understand audio"
+        print("Google Speech Recognition could not understand audio")
     except sr.RequestError as e:
-        print "Could not request results from Google Speech Recognition service; {0}".format(e)
+        print("Could not request results from Google Speech Recognition service; {0}".format(e))
 
     os.remove(fname)
 
@@ -51,8 +51,8 @@ def interrupt_callback():
     return interrupted
 
 if len(sys.argv) == 1:
-    print "Error: need to specify model name"
-    print "Usage: python demo.py your.model"
+    print("Error: need to specify model name")
+    print("Usage: python demo.py your.model")
     sys.exit(-1)
 
 model = sys.argv[1]
@@ -61,7 +61,7 @@ model = sys.argv[1]
 signal.signal(signal.SIGINT, signal_handler)
 
 detector = snowboydecoder.HotwordDetector(model, sensitivity=0.38)
-print "Listening... Press Ctrl+C to exit"
+print("Listening... Press Ctrl+C to exit")
 
 # main loop
 detector.start(detected_callback=detectedCallback,
@@ -70,7 +70,3 @@ detector.start(detected_callback=detectedCallback,
                sleep_time=0.01)
 
 detector.terminate()
-
-
-
-

--- a/examples/Python/demo_threaded.py
+++ b/examples/Python/demo_threaded.py
@@ -3,6 +3,11 @@ import sys
 import signal
 import time
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
 stop_program = False
 
 # This a demo that shows running Snowboy in another thread
@@ -40,8 +45,8 @@ while not stop_program:
     try:
         num1 = int(raw_input("Enter the first number to add: "))
         num2 = int(raw_input("Enter the second number to add: "))
-        print "Sum of number: {}".format(num1 + num2)
+        print("Sum of number: {}".format(num1 + num2))
     except ValueError:
-        print "You did not enter a number."
+        print("You did not enter a number.")
 
 threaded_detector.terminate()

--- a/examples/Python/snowboydecoder_arecord.py
+++ b/examples/Python/snowboydecoder_arecord.py
@@ -5,6 +5,7 @@ import snowboydetect
 import time
 import wave
 import os
+import sys
 import logging
 import subprocess
 import threading
@@ -180,16 +181,16 @@ class HotwordDetector(object):
                 callback = detected_callback[ans-1]
                 if callback is not None:
                     callback()
-		matrix_demos_dir = "/home/pi/matrix-creator-hal/build/demos/"
-		beamforming_result_path = "/tmp/beamforming_result.flac"
-		cwd = os.getcwd()
-		print("Running from " + cwd)
-		os.system(matrix_demos_dir + "micarray_recorder")
-		print("Voice recording complete")
-		os.system("sox -r 16000 -c 1 -e signed -b 16 " + cwd + "/mic_16000_s16le_channel_8.raw /tmp/channel_8.wav")
-		os.system("flac -f -s /tmp/channel_8.wav -o /tmp/beamforming_result.flac")
-		print("Conversion from raw to flac complete")
-		#wsk_transcribe_audio("/tmp/beamforming_result.flac")
+                matrix_demos_dir = "/home/pi/matrix-creator-hal/build/demos/"
+                beamforming_result_path = "/tmp/beamforming_result.flac"
+                cwd = os.getcwd()
+                print("Running from " + cwd)
+                os.system(matrix_demos_dir + "micarray_recorder")
+                print("Voice recording complete")
+                os.system("sox -r 16000 -c 1 -e signed -b 16 " + cwd + "/mic_16000_s16le_channel_8.raw /tmp/channel_8.wav")
+                os.system("flac -f -s /tmp/channel_8.wav -o /tmp/beamforming_result.flac")
+                print("Conversion from raw to flac complete")
+                #wsk_transcribe_audio("/tmp/beamforming_result.flac")
         logger.debug("finished.")
 
     def terminate(self):
@@ -199,4 +200,3 @@ class HotwordDetector(object):
         """
         self.recording = False
         self.record_thread.join()
-

--- a/examples/Python3/demo4.py
+++ b/examples/Python3/demo4.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import snowboydecoder
 import sys
 import signal
@@ -69,7 +71,3 @@ detector.start(detected_callback=detectedCallback,
                sleep_time=0.01)
 
 detector.terminate()
-
-
-
-

--- a/examples/REST_API/training_service.py
+++ b/examples/REST_API/training_service.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     try:
         [_, wav1, wav2, wav3, out] = sys.argv
     except ValueError:
-        print "Usage: %s wave_file1 wave_file2 wave_file3 out_model_name" % sys.argv[0]
+        print("Usage: %s wave_file1 wave_file2 wave_file3 out_model_name" % sys.argv[0])
         sys.exit()
 
     data = {
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     if response.ok:
         with open(out, "w") as outfile:
             outfile.write(response.content)
-        print "Saved model to '%s'." % out
+        print("Saved model to '%s'." % out)
     else:
-        print "Request failed."
-        print response.text
+        print("Request failed.")
+        print(response.text)


### PR DESCRIPTION
Fix the following issues which can raise NameError, SyntaxError, or TabError at runtime:
### Python 2
$ __python2 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./examples/Python3/demo4.py:41:34: E999 SyntaxError: invalid syntax
  print('recording audio...', end='', flush=True)
                                 ^
./examples/Python/snowboydecoder_arecord.py:114:9: F821 undefined name 'sys'
        sys.exit(0)
        ^
1     E999 SyntaxError: invalid syntax
1     F821 undefined name 'sys'
2
```
### Python 3
$ __python3 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./examples/Python/snowboydecoder_arecord.py:184:63: E999 TabError: inconsistent use of tabs and spaces in indentation
		matrix_demos_dir = "/home/pi/matrix-creator-hal/build/demos/"
                                                              ^
./examples/Python/demo_threaded.py:43:33: E999 SyntaxError: invalid syntax
        print "Sum of number: {}".format(num1 + num2)
                                ^
./examples/Python/demo4.py:21:36: E999 SyntaxError: invalid syntax
    print "converting audio to text"
                                   ^
./examples/REST_API/training_service.py:28:73: E999 SyntaxError: invalid syntax
        print "Usage: %s wave_file1 wave_file2 wave_file3 out_model_name" % sys.argv[0]
                                                                        ^
4     E999 SyntaxError: invalid syntax
4
```